### PR TITLE
Update web support for maps_launcher

### DIFF
--- a/lib/maps_launcher.dart
+++ b/lib/maps_launcher.dart
@@ -14,7 +14,7 @@ class MapsLauncher {
 
     if (kIsWeb) {
       uri = Uri.https(
-          'www.google.com', '/maps/search', {'api': '1', 'query': query});
+          'www.google.com', '/maps/search/', {'api': '1', 'query': query});
     } else if (Platform.isAndroid) {
       uri = Uri(scheme: 'geo', host: '0,0', queryParameters: {'q': query});
     } else if (Platform.isIOS) {
@@ -35,7 +35,7 @@ class MapsLauncher {
     var uri;
 
     if (kIsWeb) {
-      uri = Uri.https('www.google.com', '/maps/search',
+      uri = Uri.https('www.google.com', '/maps/search/',
           {'api': '1', 'query': '$latitude,$longitude'});
     } else if (Platform.isAndroid) {
       var query = '$latitude,$longitude';

--- a/lib/maps_launcher_web.dart
+++ b/lib/maps_launcher_web.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+// In order to *not* need this ignore, consider extracting the "web" version
+// of your plugin as a separate package, instead of inlining it in the same
+// package as the core of your plugin.
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html show window;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+/// A web implementation of the MapsLauncher plugin.
+class MapsLauncherWeb {
+  static void registerWith(Registrar registrar) {
+    final MethodChannel channel = MethodChannel(
+      'maps_launcher',
+      const StandardMethodCodec(),
+      registrar.messenger,
+    );
+
+    final pluginInstance = MapsLauncherWeb();
+    channel.setMethodCallHandler(pluginInstance.handleMethodCall);
+  }
+
+  /// Handles method calls over the MethodChannel of this plugin.
+  /// Note: Check the "federated" architecture for a new way of doing this:
+  /// https://flutter.dev/go/federated-plugins
+  Future<dynamic> handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'getPlatformVersion':
+        return getPlatformVersion();
+        break;
+      default:
+        throw PlatformException(
+          code: 'Unimplemented',
+          details: 'maps_launcher for web doesn\'t implement \'${call.method}\'',
+        );
+    }
+  }
+
+  /// Returns a [String] containing the version of the platform.
+  Future<String> getPlatformVersion() {
+    final version = html.window.navigator.userAgent;
+    return Future.value(version);
+  }
+}


### PR DESCRIPTION
@pikaju it seems that web support broke in one of the later versions: https://github.com/pikaju/flutter-maps-launcher/issues/6


I resolved this via `flutter create --template=plugin --platforms=web .` as described here: https://flutter.dev/docs/development/packages-and-plugins/developing-packages#add-support-for-platforms-in-an-existing-plugin-project

Additionally it looks like web is now requiring a trailing slash, not sure when that got changed.