### PR TITLE
fix(ios): apple maps launchCoordinates launches maps with pin

### DIFF
--- a/lib/maps_launcher.dart
+++ b/lib/maps_launcher.dart
@@ -42,9 +42,9 @@ class MapsLauncher {
 
       uri = Uri(scheme: 'geo', host: '0,0', queryParameters: {'q': query});
     } else if (Platform.isIOS) {
-      var params = {'ll': '$latitude,$longitude'};
+      var params = {'q': '$latitude,$longitude'};
 
-      if (label != null) params['q'] = label;
+      // if (label != null) params['q'] = label;
 
       uri = Uri.https('maps.apple.com', '/', params);
     } else {


### PR DESCRIPTION
Running the following only centers the map on iOS Apple Maps:
```
MapsLauncher.launchCoordinates(
      mylat,
      mylng,
    );
```

Changing the Apple Maps URL creation to use `q` instead of `ll` drops the pin as hoped for.

I tried using `sll` [as documented](https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html) but it just refused to work. I would like for someone else to verify this, though.